### PR TITLE
Redesign, the library now allows to extend the destination of the log…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Win64
 __history
 *.identcache
 *.~dsk
+*.stat

--- a/demos/GUIDemo/LogGUIDemo.dpr
+++ b/demos/GUIDemo/LogGUIDemo.dpr
@@ -3,7 +3,8 @@ program LogGUIDemo;
 uses
   Vcl.Forms,
   ufrmMain in 'ufrmMain.pas' {Form3},
-  UjachLogMgr in '..\..\src\UjachLogMgr.pas';
+  UjachLogMgr in '..\..\src\UjachLogMgr.pas',
+  ujachLogToDisk in '..\..\src\ujachLogToDisk.pas';
 
 {$R *.res}
 

--- a/demos/GUIDemo/LogGUIDemo.dproj
+++ b/demos/GUIDemo/LogGUIDemo.dproj
@@ -107,6 +107,7 @@
             <FormType>dfm</FormType>
         </DCCReference>
         <DCCReference Include="..\..\src\UjachLogMgr.pas"/>
+        <DCCReference Include="..\..\src\ujachLogToDisk.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/demos/GUIDemo/ufrmMain.dfm
+++ b/demos/GUIDemo/ufrmMain.dfm
@@ -2,7 +2,7 @@ object Form3: TForm3
   Left = 0
   Top = 0
   Caption = 'Form3'
-  ClientHeight = 201
+  ClientHeight = 360
   ClientWidth = 447
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -57,5 +57,77 @@ object Form3: TForm3
     Caption = 'Write FatalError'
     TabOrder = 4
     OnClick = Button5Click
+  end
+  object Button6: TButton
+    Left = 248
+    Top = 8
+    Width = 125
+    Height = 25
+    Caption = 'Clear cache'
+    TabOrder = 5
+    OnClick = Button6Click
+  end
+  object Button7: TButton
+    Left = 248
+    Top = 39
+    Width = 125
+    Height = 25
+    Caption = 'Cache write Msg'
+    TabOrder = 6
+    OnClick = Button7Click
+  end
+  object Button8: TButton
+    Left = 248
+    Top = 70
+    Width = 125
+    Height = 25
+    Caption = 'Cache write Warn'
+    TabOrder = 7
+    OnClick = Button8Click
+  end
+  object Button9: TButton
+    Left = 248
+    Top = 101
+    Width = 125
+    Height = 25
+    Caption = 'Cache write Error'
+    TabOrder = 8
+    OnClick = Button9Click
+  end
+  object Button10: TButton
+    Left = 248
+    Top = 132
+    Width = 125
+    Height = 25
+    Caption = 'Cache write Fatal Error'
+    TabOrder = 9
+    OnClick = Button10Click
+  end
+  object Button11: TButton
+    Left = 248
+    Top = 163
+    Width = 125
+    Height = 25
+    Caption = 'Write cache'
+    TabOrder = 10
+    OnClick = Button11Click
+  end
+  object Button12: TButton
+    Left = 248
+    Top = 194
+    Width = 125
+    Height = 25
+    Caption = 'Force write cache'
+    TabOrder = 11
+    OnClick = Button12Click
+  end
+  object Button13: TButton
+    Left = 248
+    Top = 225
+    Width = 125
+    Height = 25
+    Caption = 'Cache 1000 messages'
+    TabOrder = 12
+    OnClick = Button13Click
   end
 end

--- a/demos/GUIDemo/ufrmMain.pas
+++ b/demos/GUIDemo/ufrmMain.pas
@@ -13,11 +13,27 @@ type
     Button3: TButton;
     Button4: TButton;
     Button5: TButton;
+    Button6: TButton;
+    Button7: TButton;
+    Button8: TButton;
+    Button9: TButton;
+    Button10: TButton;
+    Button11: TButton;
+    Button12: TButton;
+    Button13: TButton;
     procedure Button1Click(Sender: TObject);
     procedure Button2Click(Sender: TObject);
     procedure Button3Click(Sender: TObject);
     procedure Button4Click(Sender: TObject);
     procedure Button5Click(Sender: TObject);
+    procedure Button6Click(Sender: TObject);
+    procedure Button7Click(Sender: TObject);
+    procedure Button8Click(Sender: TObject);
+    procedure Button9Click(Sender: TObject);
+    procedure Button10Click(Sender: TObject);
+    procedure Button11Click(Sender: TObject);
+    procedure Button12Click(Sender: TObject);
+    procedure Button13Click(Sender: TObject);
   private
   public
   end;
@@ -33,6 +49,29 @@ uses
 
 {$R *.dfm}
 
+procedure TForm3.Button10Click(Sender: TObject);
+begin
+  TjachLog.CacheLogFatalError('This is a fatal error');
+end;
+
+procedure TForm3.Button11Click(Sender: TObject);
+begin
+  TjachLog.WriteCachedLog;
+end;
+
+procedure TForm3.Button12Click(Sender: TObject);
+begin
+  TjachLog.ForceWriteCachedLog;
+end;
+
+procedure TForm3.Button13Click(Sender: TObject);
+var
+  I: Integer;
+begin
+  for I := 1 to 1000 do
+    TjachLog.CacheLogMessage('Logged message #%d', [I]);
+end;
+
 procedure TForm3.Button1Click(Sender: TObject);
 begin
   TjachLog.IsActive := not TjachLog.IsActive;
@@ -42,7 +81,7 @@ procedure TForm3.Button2Click(Sender: TObject);
 var
   I: Integer;
 begin
-  TjachLog.MaxFileSize := 50 * 1024;
+  //TjachLog.MaxFileSize := 50 * 1024;
   TjachLog.LogMessage('Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola '
     + 'Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola '
     + 'Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola Hola '
@@ -82,6 +121,26 @@ end;
 procedure TForm3.Button5Click(Sender: TObject);
 begin
   TjachLog.LogFatalError('Error que jode todo');
+end;
+
+procedure TForm3.Button6Click(Sender: TObject);
+begin
+  TjachLog.CacheClear;
+end;
+
+procedure TForm3.Button7Click(Sender: TObject);
+begin
+  TjachLog.CacheLogMessage('This is a message');
+end;
+
+procedure TForm3.Button8Click(Sender: TObject);
+begin
+  TjachLog.CacheLogWarn('This is a warning');
+end;
+
+procedure TForm3.Button9Click(Sender: TObject);
+begin
+  TjachLog.CacheLogError('This is an error');
 end;
 
 end.

--- a/src/ujachLogToDisk.pas
+++ b/src/ujachLogToDisk.pas
@@ -1,0 +1,275 @@
+{ ******************************************************** }
+{ **                                                    ** }
+{ ** Basic multithreaded Log support for Delphi         ** }
+{ **                                                    ** }
+{ ** Author:                                            ** }
+{ **     Juan Antonio Castillo H. (jachguate)           ** }
+{ **                                                    ** }
+{ ** Copyright (c) 2007-2021                            ** }
+{ **                                                    ** }
+{ ** https://github.com/jachguate/jachLogMgr            ** }
+{ **                                                    ** }
+{ ** Available under MIT License                        ** }
+{ ******************************************************** }
+
+{
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+}
+unit ujachLogToDisk;
+
+interface
+
+{$define AutoRegisterjachLogToDisk}
+
+uses
+  UjachLogMgr, System.SyncObjs;
+
+type
+  TjachLogToDisk = class(TjachLogWriter)
+  private
+    FBasePath: string;
+    FFileNamePrefix: string;
+    FFileNameSuffix: string;
+
+    FLogFileName: string;
+    FLogFile: TextFile;
+
+    FIsOpen: Boolean;
+    FLock: TCriticalSection;
+    FMaxFileSize: UInt64;
+    FIsMirroredToConsole: Boolean;
+    procedure SetFileNamePrefix(const Value: string);
+    procedure SetFileNameSuffix(const Value: string);
+    procedure SetBasePath(const Value: string);
+    procedure UpdateLogFileName;
+    procedure SetMaxFileSize(const Value: UInt64);
+    procedure SetIsMirroredToConsole(const Value: Boolean);
+  protected
+    procedure OpenLogChannel; override;
+    procedure CloseLogChannel; override;
+    procedure Write(ALogType: TLogType; const S, AIndentSpaces: string;
+      const AThreadID: TThreadID; const ADateTime: TDateTime); override;
+    procedure RotateLogs;
+    function GetLock: TCriticalSection; override;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    property BasePath: string read FBasePath write SetBasePath;
+    property FileNamePrefix: string read FFileNamePrefix write SetFileNamePrefix;
+    property FileNameSuffix: string read FFileNameSuffix write SetFileNameSuffix;
+    property MaxFileSize: UInt64 read FMaxFileSize write SetMaxFileSize;
+    property IsMirroredToConsole: Boolean read FIsMirroredToConsole write SetIsMirroredToConsole;
+  end;
+
+function GetjachDiskLogger: TjachLogToDisk;
+
+implementation
+
+uses
+    System.IOUtils
+  {$ifdef MSWindows}
+  , Windows
+  {$endif}
+  , System.SysUtils
+  , System.Types;
+
+function GetDefaultBasePath: string;
+begin
+  Result := TPath.GetPublicPath() + PathDelim + 'log';
+end;
+
+{$ifdef MSWindows}
+function MyGetFileSize(const aFilename: String): Int64;
+var
+  info: TWin32FileAttributeData;
+begin
+  result := -1;
+
+  if NOT GetFileAttributesEx(PWideChar(aFileName), GetFileExInfoStandard, @info) then
+    EXIT;
+
+  result := Int64(info.nFileSizeLow) or Int64(info.nFileSizeHigh shl 32);
+end;
+{$endif}
+
+{ TjachLogToDisk }
+
+procedure TjachLogToDisk.CloseLogChannel;
+begin
+  if not FIsOpen then
+    Exit;
+
+  CloseFile(FLogFile);
+  FIsOpen := False;
+end;
+
+constructor TjachLogToDisk.Create;
+begin
+  inherited Create;
+  FLock := TCriticalSection.Create;
+  FIsMirroredToConsole := IsConsole;
+  FMaxFileSize := 20 * 1024 * 1024; //20MB
+  FBasePath := GetDefaultBasePath;
+  UpdateLogFileName;
+end;
+
+destructor TjachLogToDisk.Destroy;
+begin
+  FLock.Free;
+  if FIsOpen then
+    CloseLogChannel;
+  inherited;
+end;
+
+function TjachLogToDisk.GetLock: TCriticalSection;
+begin
+  Result := FLock;
+end;
+
+procedure TjachLogToDisk.OpenLogChannel;
+begin
+  if FIsOpen then
+    Exit;
+  AssignFile(FLogFile, FLogFileName);
+  if FileExists(FLogFileName) then
+  begin
+    {$ifdef MSWindows}
+    if MyGetFileSize(FLogFileName) >= FMaxFileSize then
+    begin
+      RotateLogs;
+      ReWrite(FLogFile);
+    end
+    else
+      Append(FLogFile);
+    {$else}
+    Append(FLogFile);
+    {$endif}
+  end
+  else begin
+    ForceDirectories(ExtractFilePath(FLogFileName));
+    ReWrite(FLogFile);
+  end;
+  FIsOpen := True;
+end;
+
+procedure TjachLogToDisk.RotateLogs;
+var
+  Path, FN, Ext: string;
+
+  function CalcFileName(Idx: Integer): string;
+  begin
+    Result := TPath.Combine(Path, FN + '.' + IntToStr(Idx) + Ext);
+  end;
+
+var
+  FileNames: array[0..5] of string;
+  I: Integer;
+begin
+  Path := ExtractFilePath(FLogFileName);
+  FN := ExtractFileName(FLogFileName);
+  Ext := ExtractFileExt(FLogFileName);
+  Delete(FN, Length(FN) - Length(Ext) + 1, Length(Ext));
+  FileNames[0] := FLogFileName;
+  for I := Low(FileNames) + 1 to High(FileNames) do
+    FileNames[I] := CalcFileName(I);
+  if TFile.Exists(FileNames[High(FileNames)], False) then
+    TFile.Delete(FileNames[High(FileNames)]);
+  for I := High(FileNames) - 1 downto Low(FileNames) do
+    if TFile.Exists(FileNames[I]) then
+      TFile.Move(FileNames[I], FileNames[I + 1]);
+end;
+
+procedure TjachLogToDisk.SetBasePath(const Value: string);
+begin
+  FBasePath := Value;
+  UpdateLogFileName;
+end;
+
+procedure TjachLogToDisk.SetFileNamePrefix(const Value: string);
+begin
+  FFileNamePrefix := Value;
+  UpdateLogFileName;
+end;
+
+procedure TjachLogToDisk.SetFileNameSuffix(const Value: string);
+begin
+  FFileNameSuffix := Value;
+  UpdateLogFileName;
+end;
+
+procedure TjachLogToDisk.SetIsMirroredToConsole(const Value: Boolean);
+begin
+  FIsMirroredToConsole := Value;
+end;
+
+procedure TjachLogToDisk.SetMaxFileSize(const Value: UInt64);
+begin
+  FMaxFileSize := Value;
+end;
+
+procedure TjachLogToDisk.UpdateLogFileName;
+var
+  Temp: string;
+begin
+  Temp := TPath.ChangeExtension(TPath.GetFileName(ParamStr(0)), '.log');
+  Temp := FFileNamePrefix + Copy(Temp, 1, Length(Temp) - 4) + FFileNameSuffix + '.log';
+  FLogFileName := TPath.Combine(FBasePath, Temp);
+end;
+
+procedure TjachLogToDisk.Write(ALogType: TLogType; const S,
+  AIndentSpaces: string; const AThreadID: TThreadID; const ADateTime: TDateTime);
+var
+  DT: string;
+  Margin: string;
+  Msgs: TStringDynArray;
+  I: Integer;
+begin
+  DT := Format('%s %.8x %-5s', [FormatDateTime('yyyy-mm-dd hh:nn:ss:zzz', ADateTime)
+    , AThreadID
+    , LogTypeToStr(ALogType)]);
+  Margin := StringOfChar(' ', Length(DT));
+  Msgs := WordWrap(S);
+  Writeln(FLogFile, DT + ' ' + AIndentSpaces + Msgs[0]);
+  if IsConsole and FIsMirroredToConsole then
+    Writeln(DT + ' ' + AIndentSpaces + Msgs[0]);
+  for I := 1 to High(Msgs) do
+  begin
+    Writeln(FLogFile, Margin + ' ' + AIndentSpaces + Msgs[I]);
+    if IsConsole and FIsMirroredToConsole then
+      Writeln(Margin + ' ' + AIndentSpaces + Msgs[I]);
+  end;
+end;
+
+var
+  InternalLogger: TjachLogToDisk;
+
+function GetjachDiskLogger: TjachLogToDisk;
+begin
+  Result := InternalLogger;
+end;
+
+initialization
+  {$ifdef AutoRegisterjachLogToDisk}
+    InternalLogger := TjachLogToDisk.Create;
+    TjachLog.RegisterLogger(InternalLogger);
+  {$else}
+    InternalLogger := nil;
+  {$endif}
+finalization
+end.


### PR DESCRIPTION
… via sub-classing the new TjachLogWriter class.

Cached logging is supported. The cached log can be discarded or posted to the different destinations by calling the CacheClear or WriteCachedLog methods of the logger object.